### PR TITLE
add Unix Timestamp to BUILDINFO file, to check dates

### DIFF
--- a/board/mathworks/common/scripts/helper_func.py
+++ b/board/mathworks/common/scripts/helper_func.py
@@ -402,7 +402,7 @@ def br_set_var(var, value, quoted=True):
 ########################
 
 def _git_verinfo(git_dir):
-    git_hash = subproc_output('git log -n 1 --pretty="%H"', cwd=git_dir)
+    git_hash = subproc_output('git log -n 1 --pretty="%H (%at)"', cwd=git_dir)
     git_hash = re.sub("\n", "", git_hash.decode("utf-8"))
     git_hash = re.sub('"',"", git_hash)
     return git_hash
@@ -428,6 +428,7 @@ def verinfo(pkg):
 def gen_verinfo_file(tgt_file):
     
     with open(tgt_file, 'w') as f:
+        f.write("#Project: <git hash of last commit> (author date, unix timestamp)")
         f.write("Buildroot: %s\n" % (_git_verinfo(BR_ROOT)))
         f.write("Linux: %s\n" % (verinfo('linux')))
         if get_cfg_var('BR2_TARGET_UBOOT') == 'y':


### PR DESCRIPTION
This adds the author's commit date, in unix timestamp format, to allow people to check the date (not just the hash) of the SD Card.

Today it's difficult to off-line check the version of the SD Card in MATLAB. This will allow people to understand when the SD Card was created, so they can try to ensure that the version is up to do with their version of MATLAB.